### PR TITLE
Target specific PHP versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 # create the production container
-FROM alpine:3.10 AS release
-RUN apk --no-cache add \
-    php7 php7-cgi php7-pcntl php7-mbstring php7-iconv php7-session php7-json
+FROM php:7.3.2-stretch AS release
+RUN docker-php-ext-install pcntl
 WORKDIR /app
 COPY . ./
 EXPOSE 80


### PR DESCRIPTION
Changing the PHP version in the Dockerfile to 7.3.3 and up will break it, 7.3.2 works fine.

Refers: https://github.com/php-pm/php-pm/issues/461#issuecomment-513566176